### PR TITLE
Fix bot hallucinations (in recommend token allocations too)

### DIFF
--- a/0.0.1/README.md
+++ b/0.0.1/README.md
@@ -78,7 +78,7 @@ export AGENT_SECRET_KEY="<secret-key-from-previous-step>"
 - Add logs to the nearai library functions like completion_and_get_tools_calls() and completions()
 
 ### The bot is hallucinating
-- Check the prompt construction. Check how many messages are being passed in context
+- Check the prompt construction. Check how many messages are being passed in the context and whether anything in them could be inducing hallucinations.
 - Ensure you're not using `llama-3p3-70b-instruct` model. It doesn't seem to work well with nearai and returns responses
 as _assistant_ messages instead of tool calls.
 - If there was a tool call, check its docstring. Only the first line is added to the tool description, the rest of the lines are parsed as args.

--- a/0.0.1/README.md
+++ b/0.0.1/README.md
@@ -81,7 +81,8 @@ export AGENT_SECRET_KEY="<secret-key-from-previous-step>"
 - Prompt and context: Check the prompt construction. Check how many messages are being passed in the context and whether anything in them could be inducing hallucinations.
 - Model: Ensure you're not using `llama-3p3-70b-instruct` model. It doesn't seem to work well with nearai and returns responses
 as _assistant_ messages instead of tool calls.
-- Tools: If there was a tool call, check its docstring since this also affects the prompt. Only the first line is added to the tool description, the rest of the lines are parsed as args.
-- Examples: Consider adding [few-shot examples](https://blog.langchain.dev/few-shot-prompting-to-improve-tool-calling-performance/) to the prompt.
+- Tools: If there was a tool call, check its docstring since this also affects the prompt. Only the first line is added to the tool description, the rest of the lines are parsed into arg parameters and descriptions e.g. `{'type': 'function', 'function': {'name': 'save_goal', 'description': 'Save a portfolio goal (growth or allowance) specified by the user.', 'parameters': {'type': 'object', 'properties': {'goal': {'description': 'The numerical value of the goal in USD', 'type': 'integer'}, 'type_': {'description': 'Either "growth" or "allowance"', 'type': 'string'}}, 'required': ['goal', 'type_']}}}`.
+- Examples: Consider adding [few-shot examples](https://blog.langchain.dev/few-shot-prompting-to-improve-tool-calling-performance/) to the prompt to help guide the bot in generating a response.
+These live in fewshots.py.
 
 

--- a/0.0.1/README.md
+++ b/0.0.1/README.md
@@ -33,6 +33,19 @@
    pip install -r requirements.txt
    ```
 
+1. Install NEAR CLI via this [link](https://docs.near.org/tools/near-cli) and connect our test agent account
+
+```
+near account import-account benevio-labs.testnet
+```
+
+1. Generate a private key and set the following in your env vars
+
+```
+export AGENT_ACCOUNT_ID="benevio-labs.testnet"
+export AGENT_SECRET_KEY="<secret-key-from-previous-step>"
+```
+
 1. Run the agent locally
 
    ```sh
@@ -41,14 +54,34 @@
    # < Assistant: Hello! I'm here
    ```
 
-   > ℹ️ In case you don't get any responses, add print to the library `nearai/agents/agent.py` file in your site-packages
 
-   ```python
-   def run_python_code(...):
-     ...
-     # ln: 152
-     except ...:
-       print(f"Error running agent code: {e}")
+1. Follow SDK logs in a different terminal
+
+   ```sh
+   tail -n 20 -f /tmp/nearai-agent-runner/ptke.near/ft-allowance-agent/0.0.1/system_log.txt
    ```
 
-   Other SDK logs can be found at `/tmp/nearai-agent-runner/ptke.near/ft-allowance-agent/0.0.1/system_log.txt`.
+
+## Troubleshooting
+
+### The bot doesn't respond
+- Check if the agent file code is running. Add the logging line mentioned below if you don't see any errors.
+   > ℹ️ In `nearai/agents/agent.py` file in your site-packages:
+
+   ```python
+      def run_python_code(...):
+      ...
+      # ln: 152
+      except ...:
+         print(f"Error running agent code: {e}")
+      ```
+- Add logs to the nearai library functions like completion_and_get_tools_calls() and completions()
+
+### The bot is hallucinating
+- Check the prompt construction. Check how many messages are being passed in context
+- Ensure you're not using `llama-3p3-70b-instruct` model. It doesn't seem to work well with nearai and returns responses
+as _assistant_ messages instead of tool calls.
+- If there was a tool call, check its docstring. Only the first line is added to the tool description, the rest of the lines are parsed as args.
+- Consider adding [few-shot examples](https://blog.langchain.dev/few-shot-prompting-to-improve-tool-calling-performance/) to the prompt.
+
+

--- a/0.0.1/README.md
+++ b/0.0.1/README.md
@@ -78,10 +78,10 @@ export AGENT_SECRET_KEY="<secret-key-from-previous-step>"
 - Add logs to the nearai library functions like completion_and_get_tools_calls() and completions()
 
 ### The bot is hallucinating
-- Check the prompt construction. Check how many messages are being passed in the context and whether anything in them could be inducing hallucinations.
-- Ensure you're not using `llama-3p3-70b-instruct` model. It doesn't seem to work well with nearai and returns responses
+- Prompt and context: Check the prompt construction. Check how many messages are being passed in the context and whether anything in them could be inducing hallucinations.
+- Model: Ensure you're not using `llama-3p3-70b-instruct` model. It doesn't seem to work well with nearai and returns responses
 as _assistant_ messages instead of tool calls.
-- If there was a tool call, check its docstring. Only the first line is added to the tool description, the rest of the lines are parsed as args.
-- Consider adding [few-shot examples](https://blog.langchain.dev/few-shot-prompting-to-improve-tool-calling-performance/) to the prompt.
+- Tools: If there was a tool call, check its docstring since this also affects the prompt. Only the first line is added to the tool description, the rest of the lines are parsed as args.
+- Examples: Consider adding [few-shot examples](https://blog.langchain.dev/few-shot-prompting-to-improve-tool-calling-performance/) to the prompt.
 
 

--- a/0.0.1/agent.py
+++ b/0.0.1/agent.py
@@ -27,7 +27,7 @@ DivvyGoalType = typing.Literal["allowance"] | typing.Literal["growth"]
 class Agent:
     def __init__(self, env: Environment):
         self.env = env
-        self._allowance_goal = 400
+        self._allowance_goal = None
         self.prices = None
         self.recommended_tokens = None
         self._near_account_id = None
@@ -255,7 +255,7 @@ Output: "noop"
         """Return the function name of the calling function as the tool name"""
         return inspect.stack()[1][3]
 
-    def get_near_account_id(self) -> typing.List[typing.Dict]:
+    def get_near_account_id(self) -> str | None:
         """Get the NEAR account ID of the user"""
         if not self.near_account_id:
             self.env.add_reply(
@@ -268,7 +268,7 @@ Output: "noop"
 
         return self.near_account_id
 
-    def get_near_account_balance(self) -> typing.List[typing.Dict]:
+    def get_near_account_balance(self) -> str | float:
         """
         Fetch and return the NEAR token balance for a user's account.
 
@@ -391,15 +391,10 @@ Output: "noop"
                 )
         return results
 
-    def recommend_token_swaps(self) -> typing.List[typing.Dict]:
+    def recommend_token_swaps(self) -> str | None:
         """
         Help the user achieve their goals (allowance, growth) by generating personalized token swap recommendations.
         """
-        # Log allowance goals
-        self.env.add_system_log(
-            f"Current allowance goal: {self.allowance_goal}", logging.DEBUG
-        )
-
         if self.allowance_goal is None:
             return (
                 "The user hasn't set an allowance goal yet. Prompt them to provide one."
@@ -424,7 +419,7 @@ Output: "noop"
             f"The user should swap the following tokens to achieve their allowance goal of {self.allowance_goal}: {result}",
         )
 
-    def save_near_account_id(self, near_id: str) -> typing.List[typing.Dict]:
+    def save_near_account_id(self, near_id: str) -> str | None:
         """Save the Near account ID the user provides"""
         if near_id and NEAR_ID_REGEX.match(near_id):
             self._persist_near_id(near_id)
@@ -437,7 +432,7 @@ Output: "noop"
                 "Please provide a valid NEAR account ID.",
             )
 
-    def save_goal(self, goal: int, type_: DivvyGoalType) -> typing.List[typing.Dict]:
+    def save_goal(self, goal: int, type_: DivvyGoalType) -> str | None:
         """Save a portfolio goal (growth or allowance) specified by the user.
 
         This function should be called when:

--- a/0.0.1/agent.py
+++ b/0.0.1/agent.py
@@ -32,9 +32,7 @@ class Agent:
         self.near_account_balance = None
         self._client = NearMpcClient(network=env.env_vars["network"])
         tool_registry = self.env.get_tool_registry()
-        tool_registry.register_tool(
-            self.recommend_token_swaps
-        )
+        tool_registry.register_tool(self.recommend_token_swaps)
         tool_registry.register_tool(self.get_near_account_id)
         tool_registry.register_tool(self.save_near_account_id)
         tool_registry.register_tool(self.get_goals)
@@ -42,9 +40,17 @@ class Agent:
         tool_registry.register_tool(self.get_near_account_balance)
         tool_registry.register_tool(self.fetch_token_prices)
 
+        # hack to disallow some builtin tools from the library. Might be fragile to future changes in which case we can blacklist them in the prompt
+        del tool_registry.tools["write_file"]
+        del tool_registry.tools["read_file"]
+        del tool_registry.tools["list_files"]
+        del tool_registry.tools["exec_command"]
+        del tool_registry.tools["query_vector_store"]
+        del tool_registry.tools["request_user_input"]
+
     @property
     def near_account_id(self) -> str | None:
-        if not self._near_account_id:
+        if self._near_account_id is None:
             self._near_account_id = self.env.read_file("near_id.txt")
         return self._near_account_id
 
@@ -53,7 +59,8 @@ class Agent:
         if self._allowance_goal is None:
             stored_goal = self.env.read_file("allowance_goal.txt")
             self.env.add_system_log(
-                f"Found stored allowance goal: {stored_goal}", logging.DEBUG)
+                f"Found stored allowance goal: {stored_goal}", logging.DEBUG
+            )
             if stored_goal:
                 self._allowance_goal = int(stored_goal)
         return self._allowance_goal
@@ -63,7 +70,8 @@ class Agent:
         if self._growth_goal is None:
             stored_goal = self.env.read_file("growth_goal.txt")
             self.env.add_system_log(
-                f"Found stored growth goal: {stored_goal}", logging.DEBUG)
+                f"Found stored growth goal: {stored_goal}", logging.DEBUG
+            )
             if stored_goal:
                 self._growth_goal = int(stored_goal)
         return self._growth_goal
@@ -72,58 +80,62 @@ class Agent:
         # A system message guides an agent to solve specific tasks.
         prompt = {
             "role": "system",
-            # disallow some builtin tools from the library
             "content": """
 You are Divvy, a financial assistant that helps users manage and grow their crypto portfolio.
-You can access NEAR account details of the user (their balance and account id).
+Your user is a crypto beginner who is looking to set up a portfolio and achieve their financial goals.
+Your executor is a backend server that can call functions to perform various tasks.
+
+-Capabilities-
+You can fetch the NEAR account ID of the user.
+You can fetch the balance of the user.
 You can provide the real-time current market prices of crypto tokens in the users wallet.
 You can allow the user to set growth and allowance goals on their portfolio.
-You are capable of recommending token swaps to achieve the user's allowance goal in stablecoins.
+You are capable of personalized recommendations for token swaps to achieve the user's allowance goal in stablecoins.
 You can also execute the token swaps to realize the desired allowance goal.
 You can also fetch the NEAR account balance of the user.
-
-Your capabilities are defined and facilitated by the tools you have access to except your disallowed tools.
-
--Disallowed tools-
-`list_files, query_vector_store, write_file, request_user_input, read_file, exec_command`.
 
 You must follow the following instructions:
 
 -Instructions-
 * Be polite and helpful to the user.
 * When introducing yourself, provide a brief description of what your purpose is.
+* Your capabilities are facilitated by the functions/tools you have been given.
 * Tell the user if you don't support a capability. Do NOT make up or provide false information or figures.
-* Do not expose the functions you have access to to the user.
+* Do not expose any tools/functions to the user.
 * Do not use figures or function call from preceding messages to generate responses.
+* The executor expects you to specify which tools it should call and in which order. If multiple functions need to be called, generate multiple tool calls.
 """,
         }
 
         # Use the model set in the metadata to generate a response
         result = None
         tools = self.env.get_tool_registry().get_all_tool_definitions()
-        tools_completion = self.env.completion_and_get_tools_calls(
-            [prompt] + [self.env.get_last_message() or ""], tools=tools
-        )
+
+        context = [prompt, self.env.get_last_message() or ""]
         self.env.add_system_log(
-            f"Should call tools: {tools_completion.tool_calls}", logging.DEBUG
+            f"Checking whether tool calls are needed: \n Prompt Context: {context} \n --- \n Registered Tools: {[t['function']['name'] for t in tools]}",
+            logging.DEBUG,
+        )
+        tools_completion = self.env.completion_and_get_tools_calls(context, tools=tools)
+        self.env.add_system_log(
+            f"Should call tools: {tools_completion.tool_calls}",
+            logging.DEBUG,
         )
 
         if tools_completion.message:
             self.env.add_reply(tools_completion.message)
         if tools_completion.tool_calls and len(tools_completion.tool_calls) > 0:
-            tool_call_results = self._handle_tool_calls(
-                tools_completion.tool_calls)
+            tool_call_results = self._handle_tool_calls(tools_completion.tool_calls)
             if len(tool_call_results) > 0:
                 self.env.add_system_log(
                     f"Got tool call results: {tool_call_results}", logging.DEBUG
                 )
 
-                context = [prompt] + self.env.list_messages() + \
-                    tool_call_results
+                context = [prompt] + self.env.list_messages() + tool_call_results
                 result = self.env.completion(context)
 
                 self.env.add_system_log(
-                    f"Got completion for tool call with results: {result}. Context: {context}",
+                    f"Got completion for tool call with results: {result}.",
                     logging.DEBUG,
                 )
 
@@ -134,12 +146,15 @@ You must follow the following instructions:
         self.env.request_user_input()
 
     @staticmethod
-    def _to_function_response(function_name: str, value: typing.Any) -> typing.Dict:
+    def _to_function_response(
+        tool_call_id: str, function_name: str, value: typing.Any
+    ) -> typing.Dict:
         """
         Use to tell the LLM the result from a function call in a structured way
         """
         return {
-            "role": "function",
+            "tool_call_id": tool_call_id,
+            "role": "tool",
             "name": function_name,
             "content": json.dumps(value),
         }
@@ -150,17 +165,16 @@ You must follow the following instructions:
 
     def get_near_account_id(self) -> typing.List[typing.Dict]:
         """Get the NEAR account ID of the user"""
-        tool_name = self._get_tool_name()
-        responses = []
         if not self.near_account_id:
             self.env.add_reply(
                 "There is no NEAR account ID right now. Please provide one.",
                 message_type="system",
             )
+            return (
+                "The user hasn't provided a NEAR account ID yet. Ask them to provide one.",
+            )
 
-        responses.append(self._to_function_response(
-            tool_name, self.near_account_id))
-        return responses
+        return self.near_account_id
 
     def get_near_account_balance(self) -> typing.List[typing.Dict]:
         """
@@ -189,93 +203,71 @@ You must follow the following instructions:
         - Adds system messages to guide the conversation flow
         - Prompts for account ID if missing
         """
-
-        tool_name = self._get_tool_name()
-        responses = []
         balance = None
         if self.near_account_id:
             balance = get_near_account_balance(self.near_account_id)
             if balance:
                 self.near_account_balance = yocto_to_near(balance)
-            self.env.add_reply("Found the user's balance",
-                               message_type="system")
+            self.env.add_reply("Found the user's balance", message_type="system")
         else:
-            self.env.add_reply(
-                "We couldn't fetch a balance because no NEAR account ID is set. What is your near account ID?",
-                message_type="system",
-            )
-        responses.append(self._to_function_response(tool_name, balance))
-        return responses
+            return "Unable to fetch balance because user hasn't provided NEAR account ID. Ask them to provide it."
+
+        return balance
 
     # IMPROVE: this function can be parameterized to only query prices for tokens user specifies and fetch all if there's no param value
     def fetch_token_prices(self):
         """Fetch the real-time market prices of the tokens in a user's wallet (e.g. NEAR, BTC, ETH, SOL)"""
-        tool_name = self._get_tool_name()
-
         self.env.add_reply(
             "Fetching the current prices of the tokens in your wallet..."
         )
         near_price = fetch_coinbase("near")
         near_price = (
-            fetch_coingecko("near") if isinstance(
-                near_price, bool) else near_price
+            fetch_coingecko("near") if isinstance(near_price, bool) else near_price
         )
 
         btc_price = fetch_coinbase("btc")
-        btc_price = fetch_coingecko("btc") if isinstance(
-            btc_price, bool) else btc_price
+        btc_price = fetch_coingecko("btc") if isinstance(btc_price, bool) else btc_price
 
         eth_price = fetch_coinbase("eth")
-        eth_price = fetch_coingecko("eth") if isinstance(
-            eth_price, bool) else eth_price
+        eth_price = fetch_coingecko("eth") if isinstance(eth_price, bool) else eth_price
 
         sol_price = fetch_coinbase("sol")
-        sol_price = fetch_coingecko("sol") if isinstance(
-            sol_price, bool) else sol_price
-        self.prices = [
-            "NEAR:",
-            near_price,
-            "BTC:",
-            btc_price,
-            "ETH:",
-            eth_price,
-            "SOL:",
-            sol_price,
-        ]
+        sol_price = fetch_coingecko("sol") if isinstance(sol_price, bool) else sol_price
+        self.prices = {
+            "NEAR": near_price,
+            "BTC": btc_price,
+            "ETH": eth_price,
+            "SOL": sol_price,
+        }
 
-        return [self._to_function_response(tool_name, self.prices)]
+        return self.prices
 
     def get_goals(self):
-        """
-        Return the goals that the user has set for their portfolio
-        This includes growth and allowance goals
-        """
-        responses = []
+        """Return the goals (growth or allowance) that the user has set for their portfolio."""
         goals = {}
         for type_, goal in [
             ("growth", self.growth_goal),
             ("allowance", self.allowance_goal),
         ]:
             if not goal:
-                self.env.add_reply(
-                    f"The user hasn't set a {type_} goal yet. Prompt them to provide one.",
-                    message_type="system",
+                goals[type_] = (
+                    f"The user hasn't set a {type_} goal yet. Prompt them to provide one."
                 )
-            goals[type_] = goal
+            else:
+                goals[type_] = goal
 
-        responses.append(self._to_function_response(
-            self._get_tool_name(), goals))
-        return responses
+        return goals
 
     def _handle_tool_calls(
         self, tool_calls: typing.List[ChatCompletionMessageToolCall]
     ) -> typing.List[typing.Dict]:
-        """Execute the tool calls and return a result for the LLM to process"""
+        """
+        Execute the tool calls and return a result for the LLM to process.
+        This is designed after Environment._handle_tool_calls which we don't use because it doesn't expose the tool
+        call results to us yet we need to pass them to the LLM for further processing.
+        """
         results = []
         for tool_call in tool_calls:
-            # exec_command tool call seems to be for executing commands on the Terminal? probably should be deregistered
-            if tool_call.function.name == "exec_command":
-                continue
             tool = self.env.get_tool_registry().get_tool(tool_call.function.name)
             if not tool:
                 self.env.add_system_log(
@@ -284,69 +276,49 @@ You must follow the following instructions:
                 )
                 continue
             args = json.loads(tool_call.function.arguments)
-            results.extend(tool(**args))
+            # TODO: wrap in a try/except
+            results.append(
+                self._to_function_response(
+                    tool_call.id, tool_call.function.name, tool(**args)
+                )
+            )
         return results
 
     def recommend_token_swaps(self) -> typing.List[typing.Dict]:
         """
-            Generate token swap recommendations to achieve the user's allowance goal in stablecoins.
-
-            This function should be called when:
-            1. The user has set an allowance goal
-            2. The user requests advice on which tokens to swap
-
-            The function will:
-            1. Consider the user's portfolio composition
-            2. Prioritize maximizing BTC holdings
-            3. Recommend optimal token quantities to swap into USDC/USDT
-            4. Preserve long-term growth potential while meeting allowance needs
-
-            Returns:
-                List[Dict]: A list containing a single function response with recommended swaps:
-                [{
-                    'token': str,           # Token symbol (e.g., 'NEAR', 'SOL')
-                    'amount': float,        # Amount of tokens to swap
-                }]
-
-            Example response:
-                [{'role': 'function',
-                'name': 'recommend_token_swaps',
-                'content': '{'NEAR': 99.04298327119977, 'SOL': 1.0781411622775472, 'ETH': 0.07348127071321557, 'BTC': 0.02280692838780696}'
-                }]
+        Help the user achieve their allowance goal by generating personalized token swap recommendations.
         """
-
-        tool_name = self._get_tool_name()
-
         # Log allowance goals
         self.env.add_system_log(
-            f"Current allowance goal: {self.allowance_goal}",
-            logging.DEBUG
+            f"Current allowance goal: {self.allowance_goal}", logging.DEBUG
         )
 
         if self.allowance_goal is None:
-            goals = self.get_goals()[0]
-            goals_dict = json.loads(goals["content"])
-            if goals_dict["allowance"]:
-                self.save_goal(int(goals_dict["allowance"]), "allowance")
+            return (
+                "The user hasn't set an allowance goal yet. Prompt them to provide one."
+            )
 
-        if not self.recommended_tokens:
+        if self.recommended_tokens is None:
             self.env.add_reply(
                 f"Considering your options with a preference for holding BTC..."
             )
             self.recommended_tokens = get_recommended_token_allocations(
-                int(self.allowance_goal)
+                self.allowance_goal
             )
 
-        if self.recommended_tokens:
-            self.env.add_system_log(
-                f"Recommended token swaps: {json.dumps(self.recommended_tokens)}",
-                logging.DEBUG
-            )
-        return [self._to_function_response(tool_name, self.recommended_tokens or [])]
+        result = ", ".join(
+            f"{key}: {value}" for key, value in self.recommended_tokens.items()
+        )
+        self.env.add_system_log(
+            f"Recommended token swaps: {self.recommended_tokens}",
+            logging.DEBUG,
+        )
+        return (
+            f"The user should swap the following tokens to achieve their allowance goal of {self.allowance_goal}: {result}",
+        )
 
     def save_near_account_id(self, near_id: str) -> typing.List[typing.Dict]:
         """Save the Near account ID the user provides"""
-        responses = []
         if near_id and NEAR_ID_REGEX.match(near_id):
             self._persist_near_id(near_id)
             self.env.add_reply(
@@ -356,7 +328,6 @@ You must follow the following instructions:
             self.env.add_reply(
                 "Please provide a valid NEAR account ID.",
             )
-        return responses
 
     def save_goal(self, goal: int, type_: DivvyGoalType) -> typing.List[typing.Dict]:
         """Save a portfolio goal (growth or allowance) specified by the user.
@@ -386,8 +357,7 @@ You must follow the following instructions:
         - Goals must be positive integers
         - Invalid inputs will prompt user for clarification
         - When multiple goals are provided, process each separately
-    """
-        responses = []
+        """
         if type_ in DIVVY_GOALS and goal > 0:
             self._persist_goal(goal, type_)
             self.env.add_reply(
@@ -397,7 +367,6 @@ You must follow the following instructions:
             self.env.add_reply(
                 "Please provide a valid goal amount and specify whether it's a growth or allowance goal.",
             )
-        return responses
 
     def _persist_near_id(self, near_id: str):
         """Persist the NEAR account ID to storage and set it to the class instance variable"""
@@ -407,14 +376,11 @@ You must follow the following instructions:
     def _persist_goal(self, goal: int, type_: DivvyGoalType) -> None:
         """Persist the growth or allowance goal to storage and set it to the class instance variable"""
         self.env.write_file(f"{type_}_goal.txt", str(goal))
+        self.env.add_system_log(f"Persisted {type_} goal: {goal}", logging.DEBUG)
         if type_ == "allowance":
-            self.env.add_system_log(
-                f"Persisted {type_} goal: {goal}",
-                logging.DEBUG
-            )
-            self._allowance_goal = goal
+            self._allowance_goal = int(goal)
         if type_ == "growth":
-            self._growth_goal = goal
+            self._growth_goal = int(goal)
 
     def execute_swap(self):
         """Execute a swap to realize the desired allowance goal"""
@@ -430,7 +396,7 @@ You must follow the following instructions:
         if not self.recommended_tokens:
             self.env.add_system_log(
                 f"Recommended tokens not found. Fetching swap options now...",
-                logging.DEBUG
+                logging.DEBUG,
             )
             self.recommend_token_allocations_to_swap_for_stablecoins()
 
@@ -466,6 +432,6 @@ You must follow the following instructions:
         # what should be our return value?
 
 
-if globals().get('env', None):
-    agent = Agent(globals().get('env', {}))
+if globals().get("env", None):
+    agent = Agent(globals().get("env", {}))
     agent.run()

--- a/0.0.1/agent.py
+++ b/0.0.1/agent.py
@@ -25,10 +25,10 @@ class Agent:
 
     def __init__(self, env: Environment):
         self.env = env
-        self._allowance_goal = 400
+        self._allowance_goal = None
         self.prices = None
         self.recommended_tokens = None
-        self._near_account_id = "ptke.near"
+        self._near_account_id = None
         self._growth_goal = None
         self.near_account_balance = None
         self._client = NearMpcClient(network=env.env_vars["network"])

--- a/0.0.1/agent.py
+++ b/0.0.1/agent.py
@@ -3,15 +3,11 @@ import json
 import logging
 import re
 import traceback
-
+import typing
 from types import SimpleNamespace
 
 from src.client import NearMpcClient
-from src.models import SignatureRequest, MpcKey, Intent
 from src.fewshots import ALL_FEWSHOT_SAMPLES
-import typing
-
-from src.client import NearMpcClient
 from src.utils import (
     fetch_coinbase,
     fetch_coingecko,

--- a/0.0.1/metadata.json
+++ b/0.0.1/metadata.json
@@ -21,10 +21,10 @@
     },
     "agent": {
       "defaults": {
-        "model": "llama-v3p1-70b-instruct",
+        "model": "llama-3p1-405b-instruct",
         "model_provider": "fireworks",
         "model_temperature": 0.5,
-        "model_max_tokens": 16384
+        "model_max_tokens": 128000
       }
     },
     "display_name": "Token Allowance Agent"

--- a/0.0.1/metadata.json
+++ b/0.0.1/metadata.json
@@ -24,7 +24,7 @@
         "model": "llama-3p1-405b-instruct",
         "model_provider": "fireworks",
         "model_temperature": 0.5,
-        "model_max_tokens": 128000
+        "model_max_tokens": 16384
       }
     },
     "display_name": "Token Allowance Agent"

--- a/0.0.1/src/fewshots.py
+++ b/0.0.1/src/fewshots.py
@@ -117,7 +117,7 @@ RECOMMEND_SWAP_SAMPLE_2 = [
     {
         "id": "example_msg_3",
         "content": """
-Definitely! Here is one way to achieve your current allowance goal of 300. You could swap these amounts of tokens in your wallet for stable coins:
+Definitely! Here is one way to achieve your current allowance goal of 300. You could swap these amounts of tokens in your wallet for stablecoins:
 * BTC: 0.1857
 * NEAR: 5.191913184
 

--- a/0.0.1/src/fewshots.py
+++ b/0.0.1/src/fewshots.py
@@ -78,7 +78,7 @@ RECOMMEND_SWAP_SAMPLE_1 = [
     {
         "id": "example_msg_3",
         "content": """
-To achieve your growth goal of 300, I recommend the following token swaps:
+To achieve your growth goal of 300, I recommend the following token swaps for USDC/USDT:
 * BTC: 0.08743453647560796
 * ETH: 0.19493149713493173
 * SOL: 0.13243573584689358

--- a/0.0.1/src/fewshots.py
+++ b/0.0.1/src/fewshots.py
@@ -1,0 +1,235 @@
+"""
+Add examples to guide the LLM when a given tool just isn't working like you want it to.
+"""
+
+# both fields are set
+GOALS_SAMPLE_1 = [
+    {
+        "id": "example_msg_1",
+        "content": "what are my goals",
+        "role": "example_user",
+    },
+    {
+        "role": "example_assistant",
+        "content": {
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "name": "get_goals",
+                    "arguments": {},
+                }
+            ]
+        },
+    },
+    {
+        "tool_call_id": "call_1",
+        "role": "tool",
+        "name": "get_goals",
+        "content": '{"growth": 200, "allowance": 400}',
+    },
+    {
+        "id": "example_msg_2",
+        "content": """Your current goals are:
+        * Growth goal: 200
+        * Allowance goal: 400 stablecoins
+        Let me know if you'd like to review or adjust these goals!
+        """,
+        "role": "example_assistant",
+    },
+]
+
+GOALS_SAMPLE_2 = [
+    {
+        "id": "example_msg_3",
+        "content": "show me my allowance goal",
+        "role": "example_user",
+    },
+    {
+        "role": "example_assistant",
+        "content": {
+            "tool_calls": [
+                {
+                    "id": "call_2",
+                    "name": "get_goals",
+                    "arguments": {},
+                }
+            ]
+        },
+    },
+    {
+        "tool_call_id": "call_2",
+        "role": "tool",
+        "name": "get_goals",
+        "content": '{"growth": "The user hasn\'t set a growth goal yet. Prompt them to provide one.", "allowance": 400}',
+    },
+    {
+        "id": "example_msg_4",
+        "content": "It looks like you haven't set a growth goal for your portfolio yet. Would you like to set one now? Additionally, I see that you have set an allowance goal of 400",
+        "role": "example_assistant",
+    },
+]
+
+# no goals are set
+GOALS_SAMPLE_3 = [
+    {
+        "id": "example_msg_5",
+        "content": "what are my goals",
+        "role": "example_user",
+    },
+    {
+        "role": "example_assistant",
+        "content": {
+            "tool_calls": [
+                {
+                    "id": "call_4",
+                    "name": "get_goals",
+                    "arguments": {},
+                }
+            ]
+        },
+    },
+    {
+        "tool_call_id": "call_4",
+        "role": "tool",
+        "name": "get_goals",
+        "content": '{"growth": "The user hasn\'t set a growth goal yet. Prompt them to provide one.", "allowance": "The user hasn\'t set a allowance goal yet. Prompt them to provide one."}',
+    },
+    {
+        "id": "example_msg_6",
+        "content": '{"growth": null, "allowance": null}',
+        "role": "example_assistant",
+    },
+]
+
+# multi function call
+# TODO: doesn't work, might be a library issue?
+MULTI_CALL_SAMPLE_1 = [
+    {
+        "id": "example_msg_1",
+        "content": "show me my balance and fetch market prices",
+        "role": "example_user",
+    },
+    {
+        "id": "example_msg_2",
+        "role": "example_assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": "call_1",
+                "name": "get_near_account_balance",
+                "arguments": {},
+            },
+            {
+                "id": "call_2",
+                "name": "fetch_token_prices",
+                "arguments": {},
+            },
+        ],
+    },
+    {
+        "tool_call_id": "call_1",
+        "role": "tool",
+        "name": "get_near_account_balance",
+        "content": "1.9181",
+    },
+    {
+        "tool_call_id": "call_2",
+        "role": "tool",
+        "name": "fetch_token_prices",
+        "content": '{"NEAR": 2.1365, "BTC": 84506.7, "ETH": 1638.99, "SOL": 129.66}',
+    },
+    {
+        "id": "example_msg_3",
+        "content": """Your current balance is 1.9181 NEAR.
+        The current market prices are:
+        * NEAR: 2.1365
+        * BTC: 84506.7
+        * ETH: 1638.99
+        * SOL: 129.66""",
+        "role": "example_assistant",
+    },
+]
+# TODO: add save_goals multi call example
+
+# recommend swaps
+RECOMMEND_SWAP_SAMPLE_1 = [
+    {
+        "id": "example_msg_1",
+        "content": "How can I reach my growth goal?",
+        "role": "example_user",
+    },
+    {
+        "id": "example_msg_2",
+        "role": "example_assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": "call_1",
+                "name": "recommend_token_swaps",
+                "arguments": {},
+            }
+        ],
+    },
+    {
+        "tool_call_id": "call_1",
+        "role": "tool",
+        "name": "recommend_token_swaps",
+        "content": '{"BTC": 0.08743453647560796, "ETH": 0.19493149713493173, "SOL": 0.13243573584689358, "NEAR": 6.2904570943770953}',
+    },
+    {
+        "id": "example_msg_3",
+        "content": """
+To achieve your growth goal of 300, I recommend the following token swaps:
+* BTC: 0.08743453647560796
+* ETH: 0.19493149713493173
+* SOL: 0.13243573584689358
+* NEAR: 6.2904570943770953
+
+Would you like me to execute these swaps for you?.""",
+        "role": "example_assistant",
+    },
+]
+
+# different wordings
+RECOMMEND_SWAP_SAMPLE_2 = [
+    {
+        "id": "example_msg_1",
+        "content": "are there some ways i can reach my goals",
+        "role": "example_user",
+    },
+    {
+        "id": "example_msg_2",
+        "role": "example_assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": "call_1",
+                "name": "recommend_token_swaps",
+                "arguments": {},
+            }
+        ],
+    },
+    {
+        "tool_call_id": "call_1",
+        "role": "tool",
+        "name": "recommend_token_swaps",
+        "content": '{"BTC": 0.1857, "NEAR": 5.191913184}',
+    },
+    {
+        "id": "example_msg_3",
+        "content": """
+Definitely! Here is one way to achieve your current allowance goal of 300. You could swap these amounts of tokens in your wallet for stable coins:
+* BTC: 0.1857
+* NEAR: 5.191913184
+
+This will rebalance your portfolio.""",
+        "role": "example_assistant",
+    },
+]
+
+
+ALL_FEWSHOT_SAMPLES = [
+    *MULTI_CALL_SAMPLE_1,
+    *RECOMMEND_SWAP_SAMPLE_1,
+    *RECOMMEND_SWAP_SAMPLE_2,
+]

--- a/0.0.1/src/fewshots.py
+++ b/0.0.1/src/fewshots.py
@@ -2,107 +2,7 @@
 Add examples to guide the LLM when a given tool just isn't working like you want it to.
 """
 
-# both fields are set
-GOALS_SAMPLE_1 = [
-    {
-        "id": "example_msg_1",
-        "content": "what are my goals",
-        "role": "example_user",
-    },
-    {
-        "role": "example_assistant",
-        "content": {
-            "tool_calls": [
-                {
-                    "id": "call_1",
-                    "name": "get_goals",
-                    "arguments": {},
-                }
-            ]
-        },
-    },
-    {
-        "tool_call_id": "call_1",
-        "role": "tool",
-        "name": "get_goals",
-        "content": '{"growth": 200, "allowance": 400}',
-    },
-    {
-        "id": "example_msg_2",
-        "content": """Your current goals are:
-        * Growth goal: 200
-        * Allowance goal: 400 stablecoins
-        Let me know if you'd like to review or adjust these goals!
-        """,
-        "role": "example_assistant",
-    },
-]
-
-GOALS_SAMPLE_2 = [
-    {
-        "id": "example_msg_3",
-        "content": "show me my allowance goal",
-        "role": "example_user",
-    },
-    {
-        "role": "example_assistant",
-        "content": {
-            "tool_calls": [
-                {
-                    "id": "call_2",
-                    "name": "get_goals",
-                    "arguments": {},
-                }
-            ]
-        },
-    },
-    {
-        "tool_call_id": "call_2",
-        "role": "tool",
-        "name": "get_goals",
-        "content": '{"growth": "The user hasn\'t set a growth goal yet. Prompt them to provide one.", "allowance": 400}',
-    },
-    {
-        "id": "example_msg_4",
-        "content": "It looks like you haven't set a growth goal for your portfolio yet. Would you like to set one now? Additionally, I see that you have set an allowance goal of 400",
-        "role": "example_assistant",
-    },
-]
-
-# no goals are set
-GOALS_SAMPLE_3 = [
-    {
-        "id": "example_msg_5",
-        "content": "what are my goals",
-        "role": "example_user",
-    },
-    {
-        "role": "example_assistant",
-        "content": {
-            "tool_calls": [
-                {
-                    "id": "call_4",
-                    "name": "get_goals",
-                    "arguments": {},
-                }
-            ]
-        },
-    },
-    {
-        "tool_call_id": "call_4",
-        "role": "tool",
-        "name": "get_goals",
-        "content": '{"growth": "The user hasn\'t set a growth goal yet. Prompt them to provide one.", "allowance": "The user hasn\'t set a allowance goal yet. Prompt them to provide one."}',
-    },
-    {
-        "id": "example_msg_6",
-        "content": '{"growth": null, "allowance": null}',
-        "role": "example_assistant",
-    },
-]
-
 # multi function call
-# TODO: doesn't work, might be a library issue?
 MULTI_CALL_SAMPLE_1 = [
     {
         "id": "example_msg_1",
@@ -190,7 +90,7 @@ Would you like me to execute these swaps for you?.""",
     },
 ]
 
-# different wordings
+# different amounts
 RECOMMEND_SWAP_SAMPLE_2 = [
     {
         "id": "example_msg_1",

--- a/0.0.1/src/fewshots.py
+++ b/0.0.1/src/fewshots.py
@@ -49,7 +49,6 @@ MULTI_CALL_SAMPLE_1 = [
         "role": "example_assistant",
     },
 ]
-# TODO: add save_goals multi call example
 
 # recommend swaps
 RECOMMEND_SWAP_SAMPLE_1 = [

--- a/0.0.1/src/utils.py
+++ b/0.0.1/src/utils.py
@@ -9,7 +9,8 @@ from typing import Dict, List, NewType, Tuple, TypedDict, Union
 
 import aiohttp
 import base58
-import near_api
+
+# import near_api
 import requests
 from cryptography.hazmat.primitives.asymmetric import ed25519
 from dotenv import load_dotenv

--- a/0.0.1/test_prompts.md
+++ b/0.0.1/test_prompts.md
@@ -107,9 +107,10 @@ Format:
 
 Your allowance and growth goals must first be set.  Note: there are currently a harded coded quantity of BTC, SOL, NEAR, and ETH tokens that will be used to suggest quantities of tokens to swap.
 
- -> recommend token swaps to realize my allowance goal
-<- Assistant: Considering your options with a preference for holding BTC...
-Assistant: I can suggest a token swap to help you achieve your allowance goal. Based on your current portfolio and market conditions, I recommend swapping a portion of your NEAR for a stablecoin, such as USDT. This swap would allow you to realize a gain of approximately 29.96 NEAR, which is equivalent to your targe
+>
+    -> recommend token swaps to realize my allowance goal
+    <- Assistant: Considering your options with a preference for holding BTC...
+    Assistant: I can suggest a token swap to help you achieve your allowance goal. Based on your current portfolio and market conditions, I recommend swapping a portion of your NEAR for a stablecoin, such as USDT. This swap would allow you to realize a gain of approximately 29.96 NEAR, which is equivalent to your targe
 
 TODO - fix the LLMs interpretation of the recommended swap results. Here's an example of when the LLM mispresented the quantities and types of tokens which were calculated:
 

--- a/0.0.1/test_prompts.md
+++ b/0.0.1/test_prompts.md
@@ -110,16 +110,7 @@ Your allowance and growth goals must first be set.  Note: there are currently a 
 >
     -> recommend token swaps to realize my allowance goal
     <- Assistant: Considering your options with a preference for holding BTC...
-    Assistant: I can suggest a token swap to help you achieve your allowance goal. Based on your current portfolio and market conditions, I recommend swapping a portion of your NEAR for a stablecoin, such as USDT. This swap would allow you to realize a gain of approximately 29.96 NEAR, which is equivalent to your targe
+    Assistant: Assistant: To achieve your allowance goal of 888, I recommend swapping the following tokens:
+    * BTC: 0.010509777332335705
 
-TODO - fix the LLMs interpretation of the recommended swap results. Here's an example of when the LLM mispresented the quantities and types of tokens which were calculated:
-
-our function returned: {'BTC': 0.025131535330388054, 'ETH': 0.15804649889455302, 'SOL': 0.23546598135175315, 'NEAR': 10.730203309033069}
-
-and the LLM responded with:
-Assistant: Considering your options with a preference for holding BTC...
-Assistant: Based on the current market prices, I recommend swapping 0.23546598 NEAR for SOL to realize your allowance goal of 3000.
-
-
-
-
+    This swap will help you reach your goal and balance your portfolio.


### PR DESCRIPTION
- We now have separate prompts for tool planning (figuring out which tools to call from a user's query) and for generating the response to the user.
- Added some fewshot tool call samples (the docstring was being entirely ignored past the first line). This seemed to help the bot get numbers wrong less. I placed them as sample messages in the messages list based on [these benchmarks](https://blog.langchain.dev/few-shot-prompting-to-improve-tool-calling-performance/) that this approach performs better than samples in the string. Ideally we want to only have these for scenarios where the bot gets it wrong really often.
- Reduced the number of messages we're passing to the bot when prompting it because this starts confusing it as they accrue. We wanna bring them back in future but as summarized context or the more sophisticated memory management other libs implement.
- Added some troubleshooting docs because it can get quite dizzying with so many contributing variables (prompt, tool docstrings, tool names, # messages in context and their content, LLM model in use)
- **Shortcoming**: The bot seems to become a bit more inflexible with these examples and follows the examples word for word. I will try to find a work around this by adding something to the prompt. I also need to tell it how to interpret instructions from the function call results since sometimes it just spits them out verbatim
