### PR TITLE
support registering public keys with intents.near

### DIFF
--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -2199,6 +2199,7 @@ dependencies = [
  "near-sdk",
  "near-workspaces",
  "omni-transaction",
+ "once_cell",
  "schemars",
  "serde",
  "serde_json",

--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -25,6 +25,7 @@ hex = "0.4.3"
 schemars = "0.8.22"
 bs58 = "0.5.1"
 near-account-id = "=1.0.0"
+once_cell = "1.21.3"
 
 
 [dev-dependencies]


### PR DESCRIPTION
add new method to handle adding the MPC public key onto the contract and registering it with intents.near

the agent-setup flow on the UI will result in a call to [this new method.](https://nearblocks.io/txns/DT8nwjeqtSYfEtay2qP6c6F28pQJUUBSR8xHjB6nBons?tab=execution#7aTnK4JSYdmzfDV3fLDboqVCNkkoydKFAyG3H1z42VPJ)

which can be verified by calling intents directly
`$ near contract call-function as-read-only intents.near public_keys_of json-args '{"account_id":"007112.auth-v0.peerfolio.near"}' network-config mainnet now
▹▹▹▸▹ Getting a response to a read-only function call ...                                                 Function execution return value (printed to stdout):
[
  "secp256k1:HBb7unKW9CWUQgmnd7fJDDgU5dGi5qGqDnETGCinJf7qHEHU3NomYWwjxH5CE9d4aaW49RhUhq9cPxAhPM94Abj"
]
`