### PR TITLE
Support implicits

### DIFF
--- a/contracts/factory/factory.rs
+++ b/contracts/factory/factory.rs
@@ -1,7 +1,7 @@
 use bs58;
 use near_sdk::serde::Serialize;
 use near_sdk::{
-    AccountId, Gas, NearToken, PanicOnDefault, Promise, PromiseError, PublicKey, env, near,
+    env, near, AccountId, Gas, NearToken, PanicOnDefault, Promise, PromiseError, PublicKey,
 };
 
 const TESTNET_SIGNER: &str = "v1.signer-prod.testnet";

--- a/contracts/factory/factory.rs
+++ b/contracts/factory/factory.rs
@@ -1,7 +1,7 @@
 use bs58;
 use near_sdk::serde::Serialize;
 use near_sdk::{
-    env, near, AccountId, Gas, NearToken, PanicOnDefault, Promise, PromiseError, PublicKey,
+    AccountId, Gas, NearToken, PanicOnDefault, Promise, PromiseError, PublicKey, env, near,
 };
 
 const TESTNET_SIGNER: &str = "v1.signer-prod.testnet";
@@ -103,8 +103,17 @@ impl ProxyFactory {
         let account_str = owner_id.as_str();
 
         if account_str.ends_with(".testnet") || account_str.ends_with(".near") {
-            let parts: Vec<&str> = account_str.rsplitn(2, '.').collect();
-            parts[1].to_string()
+            // Extract the account name
+            let domain_start = if account_str.ends_with(".testnet") {
+                account_str.len() - 8 // ".testnet".len()
+            } else {
+                account_str.len() - 5 // ".near".len()
+            };
+
+            let account_part = &account_str[..domain_start];
+
+            // Replace dots with hyphens for subaccounts
+            account_part.replace('.', "-")
         } else if account_str.len() == 64 {
             // Implicit account: take the first 32 chars
             let hash_input = &account_str[..32];

--- a/contracts/factory/factory.rs
+++ b/contracts/factory/factory.rs
@@ -117,7 +117,7 @@ impl ProxyFactory {
         } else if account_str.len() == 64 {
             // Implicit account: take the first 32 chars
             let hash_input = &account_str[..32];
-            // hash them to get 18-char result
+            // hash them and encode first 12 bytes as hex to get 24-char result
             let hash = env::sha256(hash_input.as_bytes());
             let truncated = hex::encode(&hash[..12]); // 24 chars (12 bytes * 2)
 

--- a/contracts/factory/unit_tests.rs
+++ b/contracts/factory/unit_tests.rs
@@ -251,7 +251,7 @@ mod tests {
 
         // Should start with "implicit_" and be deterministic
         assert!(base_name.starts_with("implicit_"));
-        assert_eq!(base_name.len(), 33); // "implicit_" + 25 chars (updated based on actual output)
+        assert_eq!(base_name.len(), 33); // "implicit_" (9 chars) + 24 chars = 33
 
         // Test that the same input always produces the same output
         let base_name2 = contract.get_base_account_name(&owner_id);


### PR DESCRIPTION
This PR adds adds public methods to our factory that our UI and backend can use as needed to deterministically get trading account base names