### PR TITLE
Refactor better patterns

### DIFF
--- a/contracts/actions.rs
+++ b/contracts/actions.rs
@@ -1,5 +1,20 @@
 use near_sdk::{AccountId, Gas, NearToken, near};
 
+const ALLOWED_CONTRACTS: &[&str] = &["wrap.near", "intents.near", "wrap.testnet"];
+const ALLOWED_METHODS: &[&str] = &[
+    "add_public_key",
+    "ft_transfer_call",
+    "near_deposit",
+    "mt_transfer_call",
+    "mt_transfer",
+];
+
+#[derive(Debug, PartialEq)]
+pub enum ActionValidationError {
+    ContractNotAllowed(String),
+    MethodNotAllowed(String),
+}
+
 #[near(serializers = [json, borsh])]
 #[derive(Clone)]
 pub struct NearAction {
@@ -10,25 +25,26 @@ pub struct NearAction {
 }
 
 impl NearAction {
-    pub fn is_allowed(&self) {
-        let allowed_contracts = ["wrap.near", "intents.near", "wrap.testnet"];
-        let allowed_methods = [
-            "add_public_key",
-            "ft_transfer_call",
-            "near_deposit",
-            "mt_transfer_call",
-            "mt_transfer",
-        ];
-        if !allowed_contracts.contains(&self.contract_id.as_str()) {
-            panic!(
-                "{} is not allowed. Only wrap.near, wrap.testnet, and intents.near are permitted",
-                self.contract_id
-            );
+    pub fn is_allowed(&self) -> Result<(), ActionValidationError> {
+        // Check if contract address is allowed
+        let contract_str = self.contract_id.as_str();
+        if !ALLOWED_CONTRACTS.contains(&contract_str) {
+            return Err(ActionValidationError::ContractNotAllowed(format!(
+                "{} is not allowed. Only {:?} are permitted",
+                self.contract_id, ALLOWED_CONTRACTS
+            )));
         }
+
+        // Check if method is allowed
         if let Some(method) = &self.method_name {
-            if !allowed_methods.contains(&method.as_str()) {
-                panic!("Method {} is restricted", method);
+            if !ALLOWED_METHODS.contains(&method.as_str()) {
+                return Err(ActionValidationError::MethodNotAllowed(format!(
+                    "Method {} is restricted. Allowed methods: {:?}",
+                    method, ALLOWED_METHODS
+                )));
             }
         }
+
+        Ok(())
     }
 }

--- a/contracts/actions.rs
+++ b/contracts/actions.rs
@@ -8,27 +8,40 @@ pub struct NearAction {
     pub gas_attached: Gas,
     pub deposit_attached: NearToken,
 }
+#[derive(Debug, PartialEq)]
+pub enum ActionValidationError {
+    ContractNotAllowed(String),
+    MethodNotAllowed(String),
+}
+
+const ALLOWED_CONTRACTS: &[&str] = &["wrap.near", "intents.near", "wrap.testnet"];
+const ALLOWED_METHODS: &[&str] = &[
+    "add_public_key",
+    "ft_transfer_call",
+    "near_deposit",
+    "mt_transfer_call",
+    "mt_transfer",
+];
 
 impl NearAction {
-    pub fn is_allowed(&self) {
-        let allowed_contracts = ["wrap.near", "intents.near", "wrap.testnet"];
-        let allowed_methods = [
-            "add_public_key",
-            "ft_transfer_call",
-            "near_deposit",
-            "mt_transfer_call",
-            "mt_transfer",
-        ];
-        if !allowed_contracts.contains(&self.contract_id.as_str()) {
-            panic!(
-                "{} is not allowed. Only wrap.near, wrap.testnet, and intents.near are permitted",
-                self.contract_id
-            );
+    pub fn is_allowed(&self) -> Result<(), ActionValidationError> {
+        // Check if contract address is allowed
+        let contract_str = self.contract_id.as_str();
+        if !ALLOWED_CONTRACTS.contains(&contract_str) {
+            return Err(ActionValidationError::ContractNotAllowed(format!(
+                "{} is not allowed. Only {:?} are permitted",
+                self.contract_id, ALLOWED_CONTRACTS
+            )));
         }
+        // Check if method is allowed
         if let Some(method) = &self.method_name {
-            if !allowed_methods.contains(&method.as_str()) {
-                panic!("Method {} is restricted", method);
+            if !ALLOWED_METHODS.contains(&method.as_str()) {
+                return Err(ActionValidationError::MethodNotAllowed(format!(
+                    "Method {} is restricted. Allowed methods: {:?}",
+                    method, ALLOWED_METHODS
+                )));
             }
         }
+        Ok(())
     }
 }

--- a/contracts/actions.rs
+++ b/contracts/actions.rs
@@ -1,20 +1,5 @@
 use near_sdk::{AccountId, Gas, NearToken, near};
 
-const ALLOWED_CONTRACTS: &[&str] = &["wrap.near", "intents.near", "wrap.testnet"];
-const ALLOWED_METHODS: &[&str] = &[
-    "add_public_key",
-    "ft_transfer_call",
-    "near_deposit",
-    "mt_transfer_call",
-    "mt_transfer",
-];
-
-#[derive(Debug, PartialEq)]
-pub enum ActionValidationError {
-    ContractNotAllowed(String),
-    MethodNotAllowed(String),
-}
-
 #[near(serializers = [json, borsh])]
 #[derive(Clone)]
 pub struct NearAction {
@@ -25,26 +10,25 @@ pub struct NearAction {
 }
 
 impl NearAction {
-    pub fn is_allowed(&self) -> Result<(), ActionValidationError> {
-        // Check if contract address is allowed
-        let contract_str = self.contract_id.as_str();
-        if !ALLOWED_CONTRACTS.contains(&contract_str) {
-            return Err(ActionValidationError::ContractNotAllowed(format!(
-                "{} is not allowed. Only {:?} are permitted",
-                self.contract_id, ALLOWED_CONTRACTS
-            )));
+    pub fn is_allowed(&self) {
+        let allowed_contracts = ["wrap.near", "intents.near", "wrap.testnet"];
+        let allowed_methods = [
+            "add_public_key",
+            "ft_transfer_call",
+            "near_deposit",
+            "mt_transfer_call",
+            "mt_transfer",
+        ];
+        if !allowed_contracts.contains(&self.contract_id.as_str()) {
+            panic!(
+                "{} is not allowed. Only wrap.near, wrap.testnet, and intents.near are permitted",
+                self.contract_id
+            );
         }
-
-        // Check if method is allowed
         if let Some(method) = &self.method_name {
-            if !ALLOWED_METHODS.contains(&method.as_str()) {
-                return Err(ActionValidationError::MethodNotAllowed(format!(
-                    "Method {} is restricted. Allowed methods: {:?}",
-                    method, ALLOWED_METHODS
-                )));
+            if !allowed_methods.contains(&method.as_str()) {
+                panic!("Method {} is restricted", method);
             }
         }
-
-        Ok(())
     }
 }

--- a/contracts/auth_proxy.rs
+++ b/contracts/auth_proxy.rs
@@ -1,4 +1,4 @@
-use actions::NearAction;
+use actions::{ActionValidationError, NearAction};
 use near_gas::NearGas;
 use near_sdk::base64;
 use near_sdk::collections::UnorderedSet;
@@ -174,7 +174,15 @@ impl AuthProxyContract {
                         gas_attached: NearGas::from_gas(gas_u64.0),
                         deposit_attached: deposit_near,
                     };
-                    NearAction::is_allowed(&near_action);
+                    near_action.is_allowed().unwrap_or_else(|e| {
+                        panic!(
+                            "Action validation failed: {}",
+                            match e {
+                                ActionValidationError::ContractNotAllowed(msg) => msg,
+                                ActionValidationError::MethodNotAllowed(msg) => msg,
+                            }
+                        );
+                    });
 
                     // Convert args to bytes
                     let args_bytes = serde_json::to_vec(&args)

--- a/contracts/auth_proxy.rs
+++ b/contracts/auth_proxy.rs
@@ -44,7 +44,7 @@ const NEAR_MPC_DOMAIN_ID: u32 = 0;
 
 #[near(contract_state)]
 #[derive(PanicOnDefault)]
-pub struct AuthProxyContract {
+pub struct TradingAccountContract {
     owner_id: AccountId,
     authorized_users: UnorderedSet<AccountId>,
     signer_id: AccountId,
@@ -73,7 +73,7 @@ pub trait ExtSelf {
 }
 
 #[near]
-impl AuthProxyContract {
+impl TradingAccountContract {
     #[init]
     pub fn new(owner_id: AccountId, signer_id: AccountId) -> Self {
         assert!(!env::state_exists(), "Contract is already initialized");

--- a/contracts/auth_proxy.rs
+++ b/contracts/auth_proxy.rs
@@ -125,6 +125,22 @@ impl AuthProxyContract {
         if actions.is_empty() {
             return Err("Actions cannot be empty. At least one action is required.".to_string());
         }
+
+        // Ensure Transfer actions are accompanied by at least one FunctionCall action
+        let has_transfer = actions
+            .iter()
+            .any(|action| matches!(action, ActionString::Transfer { .. }));
+        let has_function_call = actions
+            .iter()
+            .any(|action| matches!(action, ActionString::FunctionCall { .. }));
+
+        if has_transfer && !has_function_call {
+            return Err(
+                "Transfer actions must be accompanied by at least one FunctionCall action"
+                    .to_string(),
+            );
+        }
+
         actions
             .into_iter()
             .map(|action| match action {

--- a/contracts/auth_proxy.rs
+++ b/contracts/auth_proxy.rs
@@ -479,7 +479,7 @@ impl AuthProxyContract {
         base64_tx
     }
 
-    pub fn test_recover(&self, hash: Vec<u8>, signature: Vec<u8>, v: u8) -> Option<String> {
+    fn test_recover(&self, hash: Vec<u8>, signature: Vec<u8>, v: u8) -> Option<String> {
         let recovered: Option<[u8; 64]> = env::ecrecover(&hash, &signature, v, true);
 
         env::log_str(&format!("Hash: {}", hex::encode(&hash)));

--- a/contracts/auth_proxy.rs
+++ b/contracts/auth_proxy.rs
@@ -277,7 +277,12 @@ impl AuthProxyContract {
         // construct the entire transaction to be signed
         let tx = TransactionBuilder::new::<NEAR>()
             .signer_id(env::current_account_id().to_string())
-            .signer_public_key(mpc_signer_pk.to_public_key().unwrap())
+            .signer_public_key(match mpc_signer_pk.to_public_key() {
+                Ok(pk) => pk,
+                Err(e) => {
+                    env::panic_str(&format!("Invalid MPC public key format: {}", e));
+                }
+            })
             .nonce(nonce.0) // Use the provided nonce
             .receiver_id(contract_id.to_string())
             .block_hash(OmniBlockHash(block_hash.into()))

--- a/contracts/auth_proxy.rs
+++ b/contracts/auth_proxy.rs
@@ -1,4 +1,4 @@
-use actions::{ActionValidationError, NearAction};
+use actions::NearAction;
 use near_gas::NearGas;
 use near_sdk::base64;
 use near_sdk::collections::UnorderedSet;
@@ -174,15 +174,7 @@ impl AuthProxyContract {
                         gas_attached: NearGas::from_gas(gas_u64.0),
                         deposit_attached: deposit_near,
                     };
-                    near_action.is_allowed().unwrap_or_else(|e| {
-                        panic!(
-                            "Action validation failed: {}",
-                            match e {
-                                ActionValidationError::ContractNotAllowed(msg) => msg,
-                                ActionValidationError::MethodNotAllowed(msg) => msg,
-                            }
-                        );
-                    });
+                    NearAction::is_allowed(&near_action);
 
                     // Convert args to bytes
                     let args_bytes = serde_json::to_vec(&args)

--- a/contracts/factory/factory.rs
+++ b/contracts/factory/factory.rs
@@ -1,7 +1,7 @@
 use bs58;
 use near_sdk::serde::Serialize;
 use near_sdk::{
-    env, near, AccountId, Gas, NearToken, PanicOnDefault, Promise, PromiseError, PublicKey,
+    AccountId, Gas, NearToken, PanicOnDefault, Promise, PromiseError, PublicKey, env, near,
 };
 
 const TESTNET_SIGNER: &str = "v1.signer-prod.testnet";
@@ -11,14 +11,14 @@ mod unit_tests;
 
 #[near(contract_state)]
 #[derive(PanicOnDefault)]
-pub struct ProxyFactory {
+pub struct TradingAccountFactory {
     signer_contract: AccountId,
     global_proxy_base58_hash: Vec<u8>,
     owner_id: AccountId,
 }
 
 #[near]
-impl ProxyFactory {
+impl TradingAccountFactory {
     #[init]
     pub fn new(network: String, global_proxy_base58_hash: String) -> Self {
         assert!(!env::state_exists(), "Already initialized");
@@ -188,7 +188,7 @@ impl ProxyFactory {
 }
 
 #[cfg(test)]
-impl ProxyFactory {
+impl TradingAccountFactory {
     pub(crate) fn test_get_base_account_name(&self, owner_id: &AccountId) -> String {
         self.get_base_account_name(owner_id)
     }

--- a/contracts/factory/unit_tests.rs
+++ b/contracts/factory/unit_tests.rs
@@ -1,10 +1,11 @@
 #[cfg(test)]
 mod tests {
 
-    use crate::ProxyFactory;
+    use crate::TradingAccountFactory;
     use near_sdk::{
-        test_utils::{accounts, VMContextBuilder},
-        testing_env, AccountId, Gas, NearToken, Promise, PublicKey,
+        AccountId, Gas, NearToken, Promise, PublicKey,
+        test_utils::{VMContextBuilder, accounts},
+        testing_env,
     };
     use std::str::FromStr;
 
@@ -29,7 +30,7 @@ mod tests {
         let context = get_context(accounts(1), "factory.testnet".parse().unwrap(), None);
         testing_env!(context.build());
 
-        let contract = ProxyFactory::new(
+        let contract = TradingAccountFactory::new(
             "testnet".to_string(),
             "EaFtguW8o7cna1k8EtD4SFfGNdivuCPhx2Qautn7J3Rz".to_string(),
         );
@@ -49,7 +50,7 @@ mod tests {
         );
         testing_env!(context.build());
 
-        let mut contract = ProxyFactory::new(
+        let mut contract = TradingAccountFactory::new(
             "testnet".to_string(),
             "EaFtguW8o7cna1k8EtD4SFfGNdivuCPhx2Qautn7J3Rz".to_string(),
         );
@@ -61,7 +62,7 @@ mod tests {
         let context = get_context(accounts(1), "factory.testnet".parse().unwrap(), None);
         testing_env!(context.build());
 
-        let contract = ProxyFactory::new(
+        let contract = TradingAccountFactory::new(
             "testnet".to_string(),
             "EaFtguW8o7cna1k8EtD4SFfGNdivuCPhx2Qautn7J3Rz".to_string(),
         );
@@ -82,7 +83,7 @@ mod tests {
         let context = get_context(accounts(1), "factory.testnet".parse().unwrap(), None);
         testing_env!(context.build());
 
-        let contract = ProxyFactory::new(
+        let contract = TradingAccountFactory::new(
             "mainnet".to_string(),
             "EaFtguW8o7cna1k8EtD4SFfGNdivuCPhx2Qautn7J3Rz".to_string(),
         );
@@ -104,7 +105,7 @@ mod tests {
         );
         testing_env!(context.build());
 
-        let mut contract = ProxyFactory::new(
+        let mut contract = TradingAccountFactory::new(
             "testnet".to_string(),
             "EaFtguW8o7cna1k8EtD4SFfGNdivuCPhx2Qautn7J3Rz".to_string(),
         );
@@ -120,7 +121,7 @@ mod tests {
         let context = get_context(accounts(1), "factory.testnet".parse().unwrap(), None);
         testing_env!(context.build());
 
-        let mut contract = ProxyFactory::new(
+        let mut contract = TradingAccountFactory::new(
             "testnet".to_string(),
             "EaFtguW8o7cna1k8EtD4SFfGNdivuCPhx2Qautn7J3Rz".to_string(),
         );
@@ -139,7 +140,7 @@ mod tests {
         let context = get_context(accounts(1), accounts(1), None);
         testing_env!(context.build());
 
-        let mut contract = ProxyFactory::new(
+        let mut contract = TradingAccountFactory::new(
             "testnet".to_string(),
             "EaFtguW8o7cna1k8EtD4SFfGNdivuCPhx2Qautn7J3Rz".to_string(),
         );
@@ -158,7 +159,7 @@ mod tests {
         let context = get_context(accounts(2), "factory.testnet".parse().unwrap(), None); // Different account
         testing_env!(context.build());
 
-        let mut contract = ProxyFactory::new(
+        let mut contract = TradingAccountFactory::new(
             "testnet".to_string(),
             "EaFtguW8o7cna1k8EtD4SFfGNdivuCPhx2Qautn7J3Rz".to_string(),
         );
@@ -172,7 +173,7 @@ mod tests {
         let context = get_context(accounts(1), accounts(1), None);
         testing_env!(context.build());
 
-        let contract = ProxyFactory::new(
+        let contract = TradingAccountFactory::new(
             "testnet".to_string(),
             "EaFtguW8o7cna1k8EtD4SFfGNdivuCPhx2Qautn7J3Rz".to_string(),
         );
@@ -191,7 +192,7 @@ mod tests {
         let context = get_context(accounts(1), accounts(1), None);
         testing_env!(context.build());
 
-        let mut contract = ProxyFactory::new(
+        let mut contract = TradingAccountFactory::new(
             "testnet".to_string(),
             "EaFtguW8o7cna1k8EtD4SFfGNdivuCPhx2Qautn7J3Rz".to_string(),
         );
@@ -208,7 +209,7 @@ mod tests {
         let context = get_context(accounts(1), "factory.testnet".parse().unwrap(), None);
         testing_env!(context.build());
 
-        let contract = ProxyFactory::new(
+        let contract = TradingAccountFactory::new(
             "testnet".to_string(),
             "EaFtguW8o7cna1k8EtD4SFfGNdivuCPhx2Qautn7J3Rz".to_string(),
         );
@@ -239,7 +240,7 @@ mod tests {
         let context = get_context(accounts(1), "factory.testnet".parse().unwrap(), None);
         testing_env!(context.build());
 
-        let contract = ProxyFactory::new(
+        let contract = TradingAccountFactory::new(
             "testnet".to_string(),
             "EaFtguW8o7cna1k8EtD4SFfGNdivuCPhx2Qautn7J3Rz".to_string(),
         );
@@ -270,7 +271,7 @@ mod tests {
         let context = get_context(accounts(1), "factory.testnet".parse().unwrap(), None);
         testing_env!(context.build());
 
-        let contract = ProxyFactory::new(
+        let contract = TradingAccountFactory::new(
             "testnet".to_string(),
             "EaFtguW8o7cna1k8EtD4SFfGNdivuCPhx2Qautn7J3Rz".to_string(),
         );
@@ -297,7 +298,7 @@ mod tests {
         let context = get_context(accounts(1), "factory.testnet".parse().unwrap(), None);
         testing_env!(context.build());
 
-        let contract = ProxyFactory::new(
+        let contract = TradingAccountFactory::new(
             "testnet".to_string(),
             "EaFtguW8o7cna1k8EtD4SFfGNdivuCPhx2Qautn7J3Rz".to_string(),
         );
@@ -313,7 +314,7 @@ mod tests {
         let context = get_context(accounts(1), "factory.testnet".parse().unwrap(), None);
         testing_env!(context.build());
 
-        let contract = ProxyFactory::new(
+        let contract = TradingAccountFactory::new(
             "testnet".to_string(),
             "EaFtguW8o7cna1k8EtD4SFfGNdivuCPhx2Qautn7J3Rz".to_string(),
         );
@@ -333,7 +334,7 @@ mod tests {
         let context = get_context(accounts(1), "factory.testnet".parse().unwrap(), None);
         testing_env!(context.build());
 
-        let contract = ProxyFactory::new(
+        let contract = TradingAccountFactory::new(
             "testnet".to_string(),
             "EaFtguW8o7cna1k8EtD4SFfGNdivuCPhx2Qautn7J3Rz".to_string(),
         );
@@ -353,7 +354,7 @@ mod tests {
         let context = get_context(accounts(1), "factory.testnet".parse().unwrap(), None);
         testing_env!(context.build());
 
-        let contract = ProxyFactory::new(
+        let contract = TradingAccountFactory::new(
             "testnet".to_string(),
             "EaFtguW8o7cna1k8EtD4SFfGNdivuCPhx2Qautn7J3Rz".to_string(),
         );
@@ -383,7 +384,7 @@ mod tests {
         let context = get_context(accounts(1), "factory.testnet".parse().unwrap(), None);
         testing_env!(context.build());
 
-        let contract = ProxyFactory::new(
+        let contract = TradingAccountFactory::new(
             "testnet".to_string(),
             "EaFtguW8o7cna1k8EtD4SFfGNdivuCPhx2Qautn7J3Rz".to_string(),
         );

--- a/contracts/unit_tests.rs
+++ b/contracts/unit_tests.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 mod tests {
     use crate::{
-        ActionString, AuthProxyContract, BigR, EcdsaSignatureResponse, EddsaSignatureResponse,
-        ScalarValue, SignatureResponse,
+        ActionString, BigR, EcdsaSignatureResponse, EddsaSignatureResponse, ScalarValue,
+        SignatureResponse, TradingAccountContract,
     };
     use near_sdk::PublicKey;
     use near_sdk::{
@@ -27,7 +27,7 @@ mod tests {
     fn test_new() {
         let context = get_context(accounts(1));
         testing_env!(context.build());
-        let contract = AuthProxyContract::new(
+        let contract = TradingAccountContract::new(
             accounts(1),
             AccountId::try_from("v1.signer-prod.testnet".to_string()).unwrap(),
         );
@@ -38,7 +38,7 @@ mod tests {
     fn test_authorize_user() {
         let context = get_context(accounts(1));
         testing_env!(context.build());
-        let mut contract = AuthProxyContract::new(
+        let mut contract = TradingAccountContract::new(
             accounts(1),
             AccountId::try_from("v1.signer-prod.testnet".to_string()).unwrap(),
         );
@@ -51,7 +51,7 @@ mod tests {
     fn test_remove_authorized_user() {
         let context = get_context(accounts(1));
         testing_env!(context.build());
-        let mut contract = AuthProxyContract::new(
+        let mut contract = TradingAccountContract::new(
             accounts(1),
             AccountId::try_from("v1.signer".to_string()).unwrap(),
         );
@@ -68,7 +68,7 @@ mod tests {
     fn test_unauthorized_add_user() {
         let context = get_context(accounts(2));
         testing_env!(context.build());
-        let mut contract = AuthProxyContract::new(
+        let mut contract = TradingAccountContract::new(
             accounts(1),
             AccountId::try_from("v1.signer-prod.testnet".to_string()).unwrap(),
         );
@@ -79,7 +79,7 @@ mod tests {
     fn test_get_authorized_users() {
         let context = get_context(accounts(1));
         testing_env!(context.build());
-        let mut contract = AuthProxyContract::new(
+        let mut contract = TradingAccountContract::new(
             accounts(1),
             AccountId::try_from("v1.signer-prod.testnet".to_string()).unwrap(),
         );
@@ -98,7 +98,7 @@ mod tests {
     fn test_unauthorized_request_signature() {
         let context = get_context(accounts(2));
         testing_env!(context.build());
-        let mut contract = AuthProxyContract::new(
+        let mut contract = TradingAccountContract::new(
             accounts(1),
             AccountId::try_from("v1.signer-prod.testnet".to_string()).unwrap(),
         );
@@ -120,7 +120,7 @@ mod tests {
     fn test_disallowed_action() {
         let context = get_context(accounts(2));
         testing_env!(context.build());
-        let mut contract = AuthProxyContract::new(
+        let mut contract = TradingAccountContract::new(
             accounts(1),
             AccountId::try_from("v1.signer-prod.testnet".to_string()).unwrap(),
         );
@@ -154,7 +154,7 @@ mod tests {
     fn test_request_signature_single_transfer_action_fails() {
         let context = get_context(accounts(2));
         testing_env!(context.build());
-        let mut contract = AuthProxyContract::new(
+        let mut contract = TradingAccountContract::new(
             accounts(1),
             AccountId::try_from("v1.signer-prod.testnet".to_string()).unwrap(),
         );
@@ -186,7 +186,7 @@ mod tests {
     fn test_request_signature_multiple_actions_with_transfer_succeeds() {
         let context = get_context(accounts(2));
         testing_env!(context.build());
-        let mut contract = AuthProxyContract::new(
+        let mut contract = TradingAccountContract::new(
             accounts(1),
             AccountId::try_from("v1.signer-prod.testnet".to_string()).unwrap(),
         );
@@ -228,7 +228,7 @@ mod tests {
     fn test_request_signature_multiple_transfer_actions_without_function_call_fails() {
         let context = get_context(accounts(2));
         testing_env!(context.build());
-        let mut contract = AuthProxyContract::new(
+        let mut contract = TradingAccountContract::new(
             accounts(1),
             AccountId::try_from("v1.signer-prod.testnet".to_string()).unwrap(),
         );
@@ -306,7 +306,7 @@ mod tests {
     fn test_add_full_access_key_owner() {
         let context = get_context(accounts(1));
         testing_env!(context.build());
-        let mut contract = AuthProxyContract::new(
+        let mut contract = TradingAccountContract::new(
             accounts(1),
             AccountId::try_from("v1.signer-prod.testnet".to_string()).unwrap(),
         );
@@ -321,7 +321,7 @@ mod tests {
     fn test_add_full_access_key_non_owner() {
         let context = get_context(accounts(2));
         testing_env!(context.build());
-        let mut contract = AuthProxyContract::new(
+        let mut contract = TradingAccountContract::new(
             accounts(1),
             AccountId::try_from("v1.signer-prod.testnet".to_string()).unwrap(),
         );
@@ -334,7 +334,7 @@ mod tests {
         let mut context = get_context(accounts(1));
         context.attached_deposit(near_sdk::NearToken::from_yoctonear(1));
         testing_env!(context.build());
-        let mut contract = AuthProxyContract::new(
+        let mut contract = TradingAccountContract::new(
             accounts(1),
             AccountId::try_from("v1.signer-prod.testnet".to_string()).unwrap(),
         );
@@ -349,7 +349,7 @@ mod tests {
         let mut context = get_context(accounts(2));
         context.attached_deposit(near_sdk::NearToken::from_yoctonear(1));
         testing_env!(context.build());
-        let mut contract = AuthProxyContract::new(
+        let mut contract = TradingAccountContract::new(
             accounts(1),
             AccountId::try_from("v1.signer-prod.testnet".to_string()).unwrap(),
         );
@@ -361,7 +361,7 @@ mod tests {
     fn test_validate_and_build_actions_valid_function_call() {
         let context = get_context(accounts(1));
         testing_env!(context.build());
-        let contract = AuthProxyContract::new(
+        let contract = TradingAccountContract::new(
             accounts(1),
             AccountId::try_from("v1.signer.testnet".to_string()).unwrap(),
         );
@@ -385,7 +385,7 @@ mod tests {
     fn test_validate_and_build_actions_valid_transfer() {
         let context = get_context(accounts(1));
         testing_env!(context.build());
-        let contract = AuthProxyContract::new(
+        let contract = TradingAccountContract::new(
             accounts(1),
             AccountId::try_from("v1.signer-prod.testnet".to_string()).unwrap(),
         );
@@ -414,7 +414,7 @@ mod tests {
     fn test_validate_and_build_actions_disallowed_contract() {
         let context = get_context(accounts(1));
         testing_env!(context.build());
-        let contract = AuthProxyContract::new(
+        let contract = TradingAccountContract::new(
             accounts(1),
             AccountId::try_from("v1.signer-prod.testnet".to_string()).unwrap(),
         );
@@ -438,7 +438,7 @@ mod tests {
     fn test_validate_and_build_actions_disallowed_method() {
         let context = get_context(accounts(1));
         testing_env!(context.build());
-        let contract = AuthProxyContract::new(
+        let contract = TradingAccountContract::new(
             accounts(1),
             AccountId::try_from("v1.signer-prod.testnet".to_string()).unwrap(),
         );
@@ -462,7 +462,7 @@ mod tests {
     fn test_validate_and_build_actions_invalid_gas_format() {
         let context = get_context(accounts(1));
         testing_env!(context.build());
-        let contract = AuthProxyContract::new(
+        let contract = TradingAccountContract::new(
             accounts(1),
             AccountId::try_from("v1.signer-prod.testnet".to_string()).unwrap(),
         );
@@ -486,7 +486,7 @@ mod tests {
     fn test_validate_and_build_actions_invalid_deposit_format() {
         let context = get_context(accounts(1));
         testing_env!(context.build());
-        let contract = AuthProxyContract::new(
+        let contract = TradingAccountContract::new(
             accounts(1),
             AccountId::try_from("v1.signer-prod.testnet".to_string()).unwrap(),
         );
@@ -510,7 +510,7 @@ mod tests {
     fn test_validate_and_build_actions_multiple_actions() {
         let context = get_context(accounts(1));
         testing_env!(context.build());
-        let contract = AuthProxyContract::new(
+        let contract = TradingAccountContract::new(
             accounts(1),
             AccountId::try_from("v1.signer-prod.testnet".to_string()).unwrap(),
         );
@@ -545,7 +545,7 @@ mod tests {
     fn test_validate_and_build_actions_empty_actions() {
         let context = get_context(accounts(1));
         testing_env!(context.build());
-        let contract = AuthProxyContract::new(
+        let contract = TradingAccountContract::new(
             accounts(1),
             AccountId::try_from("v1.signer.testnet".to_string()).unwrap(),
         );
@@ -564,7 +564,7 @@ mod tests {
     fn test_create_signature_request_with_domain_id() {
         let context = get_context(accounts(1));
         testing_env!(context.build());
-        let contract = AuthProxyContract::new(
+        let contract = TradingAccountContract::new(
             accounts(1),
             AccountId::try_from("v1.signer.testnet".to_string()).unwrap(),
         );
@@ -610,7 +610,7 @@ mod tests {
     fn test_create_signature_request_without_domain_id() {
         let context = get_context(accounts(1));
         testing_env!(context.build());
-        let contract = AuthProxyContract::new(
+        let contract = TradingAccountContract::new(
             accounts(1),
             AccountId::try_from("v1.signer.testnet".to_string()).unwrap(),
         );
@@ -653,7 +653,7 @@ mod tests {
     fn test_convert_deposits_to_strings_small_numbers() {
         let context = get_context(accounts(1));
         testing_env!(context.build());
-        let contract = AuthProxyContract::new(
+        let contract = TradingAccountContract::new(
             accounts(1),
             AccountId::try_from("v1.signer-prod.testnet".to_string()).unwrap(),
         );
@@ -673,7 +673,7 @@ mod tests {
     fn test_convert_deposits_to_strings_large_numbers() {
         let context = get_context(accounts(1));
         testing_env!(context.build());
-        let contract = AuthProxyContract::new(
+        let contract = TradingAccountContract::new(
             accounts(1),
             AccountId::try_from("v1.signer-prod.testnet".to_string()).unwrap(),
         );
@@ -697,7 +697,7 @@ mod tests {
     fn test_convert_deposits_to_strings_multiple_deposits() {
         let context = get_context(accounts(1));
         testing_env!(context.build());
-        let contract = AuthProxyContract::new(
+        let contract = TradingAccountContract::new(
             accounts(1),
             AccountId::try_from("v1.signer-prod.testnet".to_string()).unwrap(),
         );


### PR DESCRIPTION
Minor refactoring only as needed to make these contracts more testable. Between commits I built, deployed and ran manual tests to ensure `request_signature` remained functional.

There is one breaking change, I've added an optional 8th parameter to `request_signaure`. Allowing callers to pass a domain_id, with a default value that points to Near `NEAR_MPC_DOMAIN_ID: u32 = 0`