### PR TITLE
AYGEtDuRFvjJ4Zjkbeak8PugbZByWG3g1tgxhyHpg6BC is the most recent global contract hash

### DIFF
--- a/contracts/factory/factory-deploy.sh
+++ b/contracts/factory/factory-deploy.sh
@@ -52,9 +52,9 @@ echo "Building contract..."
 RUSTFLAGS="-Z unstable-options" cargo +nightly near build non-reproducible-wasm --no-abi
 
 # Set variables
-# https://nearblocks.io/txns/6iyX1GMA3wGrh2qtz8hKv7ppf1ngV83nKiz8ZKDAE71a
+# https://nearblocks.io/txns/FSP5xgN2dKg4dX64dMV3P92MnvhbRYPZHqZx2cdpvuUQ
 #near contract deploy-as-global use-file /Users/charles/.nearai/registry/charleslavon.near/ft-allowance/contracts/target/near/proxy_contract.wasm as-global-hash peerfolio.testnet network-config testnet sign-with-keychain send
-GLOBAL_PROXY_CODE_HASH="CxhHoMAytiy39MSyKCJRksiWXvhYdRYncFpcVWAd4Pbg"
+GLOBAL_PROXY_CODE_HASH="AYGEtDuRFvjJ4Zjkbeak8PugbZByWG3g1tgxhyHpg6BC"
 WASM_PATH="target/near/proxy_factory.wasm"
 FACTORY_ACCOUNT="auth-v1.peerfolio.$NETWORK"
 FACTORY_OWNER="peerfolio.$NETWORK"

--- a/contracts/factory/factory.rs
+++ b/contracts/factory/factory.rs
@@ -1,7 +1,7 @@
 use bs58;
 use near_sdk::serde::Serialize;
 use near_sdk::{
-    AccountId, Gas, NearToken, PanicOnDefault, Promise, PromiseError, PublicKey, env, near,
+    env, near, AccountId, Gas, NearToken, PanicOnDefault, Promise, PromiseError, PublicKey,
 };
 
 const TESTNET_SIGNER: &str = "v1.signer-prod.testnet";

--- a/contracts/factory/unit_tests.rs
+++ b/contracts/factory/unit_tests.rs
@@ -3,9 +3,8 @@ mod tests {
 
     use crate::TradingAccountFactory;
     use near_sdk::{
-        AccountId, Gas, NearToken, Promise, PublicKey,
-        test_utils::{VMContextBuilder, accounts},
-        testing_env,
+        test_utils::{accounts, VMContextBuilder},
+        testing_env, AccountId, Gas, NearToken, Promise, PublicKey,
     };
     use std::str::FromStr;
 


### PR DESCRIPTION
our auth proxy code was deployed with this hash @ https://nearblocks.io/txns/FSP5xgN2dKg4dX64dMV3P92MnvhbRYPZHqZx2cdpvuUQ?tab=execution

This PR saves into git the expected version into our factory deploy script. 

The reason Ryan's contract is out of sync, causing [this failure](https://nearblocks.io/txns/EMeC2hnL7KUCjWG2vjpxnMHJay4n8KVHNt6qf7VMhLWh), is due to an error here whereby our factory contract only sets the global contract hash on a new deploy of `auth-v1.peerfolio.near`. If that contract already exists, the factory code itself is deployed onto `auth-v1.peerfolio.near`, but the `global_proxy_base58_hash` is [only set once when the contract is initialized](https://github.com/beneviolabs/ft-allowance-agent/pull/145/files#diff-2440aec187887c22d0bacc6203f9ec8fcee9faaaf687f49f2e0eeb14d43c23e0R95).