### PR TITLE
the factory contract's owner should be the caller who initializes it.

### DIFF
--- a/contracts/factory/factory.rs
+++ b/contracts/factory/factory.rs
@@ -1,7 +1,7 @@
 use bs58;
 use near_sdk::serde::Serialize;
 use near_sdk::{
-    AccountId, Gas, NearToken, PanicOnDefault, Promise, PromiseError, PublicKey, env, near,
+    env, near, AccountId, Gas, NearToken, PanicOnDefault, Promise, PromiseError, PublicKey,
 };
 
 const TESTNET_SIGNER: &str = "v1.signer-prod.testnet";
@@ -33,7 +33,7 @@ impl TradingAccountFactory {
         Self {
             signer_contract,
             global_proxy_base58_hash: Self::decode_code_hash(&global_proxy_base58_hash),
-            owner_id: env::current_account_id(),
+            owner_id: env::predecessor_account_id(),
         }
     }
 
@@ -174,6 +174,10 @@ impl TradingAccountFactory {
     }
 
     // View methods
+    pub fn get_owner_id(&self) -> AccountId {
+        self.owner_id.clone()
+    }
+
     pub fn get_proxy_code_base58_hash(&self) -> String {
         bs58::encode(&self.global_proxy_base58_hash).into_string()
     }

--- a/contracts/factory/unit_tests.rs
+++ b/contracts/factory/unit_tests.rs
@@ -3,9 +3,8 @@ mod tests {
 
     use crate::TradingAccountFactory;
     use near_sdk::{
-        AccountId, Gas, NearToken, Promise, PublicKey,
-        test_utils::{VMContextBuilder, accounts},
-        testing_env,
+        test_utils::{accounts, VMContextBuilder},
+        testing_env, AccountId, Gas, NearToken, Promise, PublicKey,
     };
     use std::str::FromStr;
 
@@ -27,7 +26,8 @@ mod tests {
 
     #[test]
     fn test_factory_initialization() {
-        let context = get_context(accounts(1), "factory.testnet".parse().unwrap(), None);
+        let account = accounts(1);
+        let context = get_context(account.clone(), "factory.testnet".parse().unwrap(), None);
         testing_env!(context.build());
 
         let contract = TradingAccountFactory::new(
@@ -38,6 +38,7 @@ mod tests {
             contract.get_signer_contract(),
             "v1.signer-prod.testnet".parse::<AccountId>().unwrap()
         );
+        assert_eq!(contract.get_owner_id(), account);
     }
 
     #[test]
@@ -164,7 +165,11 @@ mod tests {
             "EaFtguW8o7cna1k8EtD4SFfGNdivuCPhx2Qautn7J3Rz".to_string(),
         );
 
-        // This should fail because accounts(2) is not the owner
+        // Switch the caller to a different account (accounts(3)) so the call is unauthorized
+        let caller_context = get_context(accounts(3), "factory.testnet".parse().unwrap(), None);
+        testing_env!(caller_context.build());
+
+        // This should fail because accounts(3) is not the owner
         contract.set_global_code_hash("NewHash123456789012345678901234567890".to_string());
     }
 


### PR DESCRIPTION
Adds a public method to read the owner_id, and ensures owner is set as the caller, e.g. `peerfolio.near`, not the deployed instance, `auth-v1.peerfolio.near`